### PR TITLE
start.sh: Fix sed command

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -25,7 +25,7 @@ echo
 # Provide token to frontend
 echo "### Provide token to frontend"
 cp frontend/flask_settings.bak frontend/flask_settings 2>/dev/null
-sed -i .bak "s/TO_REPLACE_WITH_TOKEN_GENERATED_FROM_API/$token/" frontend/flask_settings
+sed -i "s/TO_REPLACE_WITH_TOKEN_GENERATED_FROM_API/$token/" frontend/flask_settings
 
 # Restart frontend so it take into account new token
 echo "### Restart frontend"


### PR DESCRIPTION
Looks like .bak as been added as mistake in the sed command arguments,
and keeping .bak is breaking the start.sh script.
Because of this .bak as been removed.

error:
sed: -e expression #1, char 1: unknown command: `.'

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@cybertrust.co.jp>