### PR TITLE
Dockerfile: need python-wheel for bdist_wheel

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/minideb:buster
 
 # Install dependencies
-RUN install_packages git python python-pip python-setuptools python-dev build-essential wget gnupg2
+RUN install_packages git python python-pip python-setuptools python-dev build-essential wget gnupg2 python-wheel
 RUN pip install python-dateutil
 
 # Install Node.js / nodemon

--- a/backend/Dockerfile-celery
+++ b/backend/Dockerfile-celery
@@ -1,7 +1,7 @@
 FROM bitnami/minideb:buster
 
 # Install dependencies
-RUN install_packages git python python-pip python-setuptools python-dev build-essential wget gnupg2
+RUN install_packages git python python-pip python-setuptools python-dev build-essential wget gnupg2 python-wheel
 
 # Configuration
 COPY celery/celery-config.cfg /etc/kernelci/kernelci-celery.cfg
@@ -21,7 +21,7 @@ RUN pip install -r /srv/kernelci-backend/requirements.txt
 COPY celery/entrypoint.sh /srv/entrypoint.sh
 
 # kcidb (NOTE: requires python3)
-RUN install_packages python3 python3-pip python3-setuptools python3-dev
+RUN install_packages python3 python3-pip python3-setuptools python3-dev python3-wheel
 RUN git clone -b v5 https://github.com/kernelci/kcidb.git /etc/kernelci/kcidb; \
   cd /etc/kernelci/kcidb; python3 -m pip install -r requirements.txt; \
     python3 -m pip install --upgrade google-cloud-pubsub; \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/minideb:buster
 
 # Install dependencies
 
-RUN install_packages build-essential git python python-pip python-setuptools python-dev uwsgi-plugin-python curl redis-tools wget
+RUN install_packages build-essential git python python-pip python-setuptools python-dev uwsgi-plugin-python curl redis-tools wget python-wheel
 
 # Install Node.js / nodemon
 RUN wget --no-check-certificate -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stacksmith/node-8.9.3-0-linux-x64-debian-8.tar.gz && \

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -10,7 +10,7 @@ RUN node /front/app/dashboard/static/js/lib/r.js -o /front/app/dashboard/static/
 
 FROM bitnami/minideb:buster as backend
 
-RUN install_packages git python python-pip python-setuptools python-dev build-essential
+RUN install_packages git python python-pip python-setuptools python-dev build-essential python-wheel
 RUN git clone https://github.com/kernelci/kernelci-backend.git /tmp/kernelci-backend
 RUN pip install -r /tmp/kernelci-backend/requirements.txt
 RUN cd /tmp/kernelci-backend/doc && make html


### PR DESCRIPTION
This commit fixes errors related to bdist_wheel,
similar to the fragment below running ./dev-start.sh
on a fresh install of the kernelci-docker:

  ----------------------------------------
  Failed building wheel for scandir
  Running setup.py clean for scandir
  Running setup.py bdist_wheel for sphinx-bootstrap-theme: started
  Running setup.py bdist_wheel for sphinx-bootstrap-theme: finished with status 'error'
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-f7uhVd/sphinx-bootstrap-theme/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-k9kl2O --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'

  ----------------------------------------

This was reproduced in:

ArchLinux
Docker version 20.10.3, build 48d30b5b32
docker-compose version 1.28.2, build unknow

Ubuntu 20.04 (Virtual Machine)
Docker version 19.03.8, build afacb8b7f0
docker-compose version 1.25.0, build unknown